### PR TITLE
Patched unset TransmitEndEvent nodeId

### DIFF
--- a/parser/handler/JsonHandler.cpp
+++ b/parser/handler/JsonHandler.cpp
@@ -675,6 +675,7 @@ void JsonHandler::parseTransmitEvent(const util::json::JsonObject &object) {
     parser::TransmitEndEvent endEvent;
     endEvent.time = event.time;
     endEvent.startEvent = transmittingIter->second.value();
+    endEvent.nodeId = endEvent.startEvent.nodeId;
     fileParser.sceneEvents.emplace_back(endEvent);
   }
   transmittingNodes[event.nodeId] = event;


### PR DESCRIPTION
The `nodeid` would be left unset when a new `TransmitEndEevnt` was created to override a previous `TransmitEvent` by the same node. This caused the simulation to block at the affected event.